### PR TITLE
Deleting messages from view and gauges on cwd editor

### DIFF
--- a/src/GaugeInput.js
+++ b/src/GaugeInput.js
@@ -98,12 +98,6 @@ class GaugeInput extends React.Component {
       ).then(result => {this.props.addToSnackbar(result)})
     }
 
-    const deleteMessage = event => {
-      const index = Number(event.target.id)
-      api.post(`glyphs/${this.state.id}/gauges/${this.state.index}/messages/${index+1}`,
-        {"pass" : this.props.pass, "text" : " ", "probability" : 0}
-      ).then(result => {this.props.addToSnackbar(result)})
-    }
 
       return (
         <div>
@@ -146,7 +140,7 @@ class GaugeInput extends React.Component {
                     />
                   )}
                   <IconButton aria-label="delete"
-                    onClick={deleteMessage}
+                    onClick={() => this.props.onDelete(this.props.id)}
                     className={classes.margin}>
                     <DeleteIcon fontSize="small" />
                   </IconButton>

--- a/src/GaugeInput.js
+++ b/src/GaugeInput.js
@@ -7,6 +7,8 @@ import ExpansionPanelSummary from '@material-ui/core/ExpansionPanelSummary'
 import ExpansionPanelDetails from '@material-ui/core/ExpansionPanelDetails'
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore'
 import Button from '@material-ui/core/Button'
+import IconButton from '@material-ui/core/IconButton';
+import DeleteIcon from '@material-ui/icons/Delete';
 import Typography from '@material-ui/core/Typography'
 
 const api = require('./api.js');
@@ -96,6 +98,13 @@ class GaugeInput extends React.Component {
       ).then(result => {this.props.addToSnackbar(result)})
     }
 
+    const deleteMessage = event => {
+      const index = Number(event.target.id)
+      api.post(`glyphs/${this.state.id}/gauges/${this.state.index}/messages/${index+1}`,
+        {"pass" : this.props.pass, "text" : " ", "probability" : 0}
+      ).then(result => {this.props.addToSnackbar(result)})
+    }
+
       return (
         <div>
           <ExpansionPanel style={{width: '100%', border: '1px solid rgba(0, 0, 0, .125)', marginTop: 10}}>
@@ -136,6 +145,11 @@ class GaugeInput extends React.Component {
                       onBlur={updateMessage}
                     />
                   )}
+                  <IconButton aria-label="delete"
+                    onClick={deleteMessage}
+                    className={classes.margin}>
+                    <DeleteIcon fontSize="small" />
+                  </IconButton>
                 </form>
               )}
               <Button variant="contained" onClick={addMessage} style={{width: '25%'}}>Add Message</Button>

--- a/src/MessageEditor.js
+++ b/src/MessageEditor.js
@@ -48,8 +48,6 @@ class MessageEditor extends React.Component {
     this.props.enqueueSnackbar(this.state.alerts[this.state.types.indexOf(variant)], { variant })
   }
 
-
-
   render() {
     const { messages, gauges } = this.state
 
@@ -59,6 +57,15 @@ class MessageEditor extends React.Component {
           this.setState({ messages: [...messages, {"text" : "Default message", "probability" : 0}]})
         }
         this.showAlert(result)
+      })
+    }
+
+    const deleteVMessage = () => {
+      api.delete(`glyphs/${this.props.id}/messages/delete`, {"pass" : this.state.pass, "text" : "Default message", "probability" : 0}).then(result => {
+        if (!result.errors) {
+          this.setState({
+            messages: this.state.messages.splice(messages.indexOf(this.props.id), 1)}) //not sure if this is the correct index, also should be checking if index == -1?
+        }
       })
     }
 

--- a/src/MessageEditor.js
+++ b/src/MessageEditor.js
@@ -3,7 +3,6 @@ import TextField from '@material-ui/core/TextField'
 import ClickAwayListener from '@material-ui/core/ClickAwayListener'
 import Button from '@material-ui/core/Button'
 import { withSnackbar } from 'notistack'
-
 import MessageInput from './MessageInput.js'
 import GaugeInput from './GaugeInput.js'
 
@@ -48,8 +47,14 @@ class MessageEditor extends React.Component {
     this.props.enqueueSnackbar(this.state.alerts[this.state.types.indexOf(variant)], { variant })
   }
 
+  handleDelete = messageID => {
+    const messages = this.state.messages.filter(message => this.props.id !== messageID)
+    this.setState({messages: messages})
+  }
+
   render() {
     const { messages, gauges } = this.state
+    const { classes } = this.props
 
     const addVMessage = () => {
       api.post(`glyphs/${this.props.id}/messages/`, {"pass" : this.state.pass, "text" : "Default message", "probability" : 0}).then(result => {
@@ -60,11 +65,11 @@ class MessageEditor extends React.Component {
       })
     }
 
-    const deleteVMessage = () => {
-      api.delete(`glyphs/${this.props.id}/messages/delete`, {"pass" : this.state.pass, "text" : "Default message", "probability" : 0}).then(result => {
+    const handleViewDeletion = () => {
+      this.handleDelete()
+      api.delete(`glyphs/${this.props.id}/messages/delete`).then(result => {
         if (!result.errors) {
-          this.setState({
-            messages: this.state.messages.splice(messages.indexOf(this.props.id), 1)}) //not sure if this is the correct index, also should be checking if index == -1?
+          this.handleDelete()
         }
       })
     }
@@ -82,14 +87,15 @@ class MessageEditor extends React.Component {
           />
         <div>
         {messages.map((m, index) =>
-          <MessageInput
-            index={index + 1}
-            id={this.props.id}
-            text={m.text}
-            prob={m.probability}
-            pass={this.state.pass}
-            addToSnackbar={this.showAlert}
-            />
+            <MessageInput
+              index={index + 1}
+              id={this.props.id}
+              text={m.text}
+              prob={m.probability}
+              pass={this.state.pass}
+              addToSnackbar={this.showAlert}
+              onDelete = {handleViewDeletion}
+              />
         )}
           <Button variant="contained" onClick={addVMessage}>Add Message To View</Button>
         </div>

--- a/src/MessageInput.js
+++ b/src/MessageInput.js
@@ -47,10 +47,6 @@ class MessageInput extends React.Component {
     ).then(result => {this.props.addToSnackbar(result)})
   }
 
-  deleteMessage = event => {
-
-  
-  }
 
   render() {
     const { classes } = this.props
@@ -82,7 +78,6 @@ class MessageInput extends React.Component {
             onBlur={this.updateMessage}
           />
           <IconButton aria-label="delete"
-            onClick={this.deleteMessage}
             className={classes.margin}>
             <DeleteIcon fontSize="small" />
           </IconButton>

--- a/src/MessageInput.js
+++ b/src/MessageInput.js
@@ -1,6 +1,8 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { withStyles } from '@material-ui/core/styles'
+import IconButton from '@material-ui/core/IconButton';
+import DeleteIcon from '@material-ui/icons/Delete';
 import TextField from '@material-ui/core/TextField'
 
 const api = require('./api.js')
@@ -45,11 +47,21 @@ class MessageInput extends React.Component {
     ).then(result => {this.props.addToSnackbar(result)})
   }
 
+  deleteMessage = event => {
+    api.post(`glyphs/${this.state.id}/messages/${this.state.index}`,
+      {"pass" : this.props.pass, "text" : " ", "probability" : 0}
+    ).then(result => {this.props.addToSnackbar(result)})
+    var elem = document.getElementById("row");
+    if (elem.parentNode) {
+      elem.parentNode.removeChild(elem);
+    }
+  }
+
   render() {
     const { classes } = this.props
 
     return (
-      <div>
+      <div id="row">
         <form className={classes.container} noValidate autoComplete="off">
           <TextField
             id="outlined-basic"
@@ -74,6 +86,11 @@ class MessageInput extends React.Component {
             onChange={this.updateProb}
             onBlur={this.updateMessage}
           />
+          <IconButton aria-label="delete"
+            onClick={this.deleteMessage}
+            className={classes.margin}>
+            <DeleteIcon fontSize="small" />
+          </IconButton>
         </form>
       </div>
     )

--- a/src/MessageInput.js
+++ b/src/MessageInput.js
@@ -1,9 +1,9 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { withStyles } from '@material-ui/core/styles'
+import TextField from '@material-ui/core/TextField'
 import IconButton from '@material-ui/core/IconButton';
 import DeleteIcon from '@material-ui/icons/Delete';
-import TextField from '@material-ui/core/TextField'
 
 const api = require('./api.js')
 
@@ -78,6 +78,7 @@ class MessageInput extends React.Component {
             onBlur={this.updateMessage}
           />
           <IconButton aria-label="delete"
+            onClick={() => this.props.onDelete(this.props.id)}
             className={classes.margin}>
             <DeleteIcon fontSize="small" />
           </IconButton>

--- a/src/MessageInput.js
+++ b/src/MessageInput.js
@@ -48,20 +48,15 @@ class MessageInput extends React.Component {
   }
 
   deleteMessage = event => {
-    api.post(`glyphs/${this.state.id}/messages/${this.state.index}`,
-      {"pass" : this.props.pass, "text" : " ", "probability" : 0}
-    ).then(result => {this.props.addToSnackbar(result)})
-    var elem = document.getElementById("row");
-    if (elem.parentNode) {
-      elem.parentNode.removeChild(elem);
-    }
+
+  
   }
 
   render() {
     const { classes } = this.props
 
     return (
-      <div id="row">
+      <div>
         <form className={classes.container} noValidate autoComplete="off">
           <TextField
             id="outlined-basic"

--- a/src/api.js
+++ b/src/api.js
@@ -21,7 +21,15 @@ const post = (url, params) => {
   .then(res => res.json());
 }
 
+const del = (url, params) => {
+  return window.fetch(`http://${API_URL}/${url}`, {
+    method: 'delete'
+  })
+  .then(res => res.json());
+}
+
 module.exports = {
   fetch,
-  post
+  post,
+  delete : del
 };


### PR DESCRIPTION
This pull request is attempting to create an option to remove messages from "view" and "gauges". I do that by updating going to the DB and updating the message to an empty string and the probability to 0. However, there are a few bugs that I do not know how to fix. One is that when I call the onClick of the delete icon button to remove an entry from the div form, it visually does so, however it also gives me a console error when I try to switch to any other tab in the editor. I suspect is has to do with how I am handling the HTML in my deleteMessage function:
```
var elem = document.getElementById("row");
    if (elem.parentNode) {
      elem.parentNode.removeChild(elem);
    }
```
which should be properly deleting one item from the form.